### PR TITLE
Test: Include git stash and pop steps in darktable build procedure

### DIFF
--- a/Notes/dtCheckUpdatesBashRawProcedure.txt
+++ b/Notes/dtCheckUpdatesBashRawProcedure.txt
@@ -1,7 +1,10 @@
 cd /Users/draco892/src/darktable
 export CMAKE_PREFIX_PATH="/opt/homebrew/opt/lua@5.4:$CMAKE_PREFIX_PATH"
+git stash
+git checkout master
 git fetch --all
 git pull
 rm -rf build                                                           
 export PREFIX="$HOME/.local"
 ./build.sh --install --build-type RelWithDebInfo --prefix "$HOME/bin/darktable-dev"
+git stash pop


### PR DESCRIPTION
Include git stash and pop steps in darktable build procedure